### PR TITLE
Update connectionsID to accepts return of type \Aws\Result

### DIFF
--- a/src/SubscriptionRepository.php
+++ b/src/SubscriptionRepository.php
@@ -36,7 +36,7 @@ class SubscriptionRepository
         $responses = Utils::all($promises)->wait();
 
         return collect($responses)
-            ->flatmap(fn (array | \Aws\Result $result): array => $result['Items'])
+            ->flatmap(fn (\Aws\Result $result): array => $result['Items'])
             ->map(fn (array $item): string => $item['connectionId']['S'])
             ->unique();
     }

--- a/src/SubscriptionRepository.php
+++ b/src/SubscriptionRepository.php
@@ -36,7 +36,7 @@ class SubscriptionRepository
         $responses = Utils::all($promises)->wait();
 
         return collect($responses)
-            ->flatmap(fn (array $result): array => $result['Items'])
+            ->flatmap(fn (array | \Aws\Result $result): array => $result['Items'])
             ->map(fn (array $item): string => $item['connectionId']['S'])
             ->unique();
     }


### PR DESCRIPTION
update SubscriptionRepository method getConnectionIdsForChannel() to accepts return of type \Aws\Result.. It's the cause of open issues and in my personal project.

#19 