### PR TITLE
Small syntactic change which makes the code PHP 7.4 compatible

### DIFF
--- a/src/ConnectionRepository.php
+++ b/src/ConnectionRepository.php
@@ -4,16 +4,18 @@ namespace Georgeboot\LaravelEchoApiGateway;
 
 use Aws\ApiGatewayManagementApi\ApiGatewayManagementApiClient;
 use Aws\ApiGatewayManagementApi\Exception\ApiGatewayManagementApiException;
-use GuzzleHttp\Exception\ClientException;
 
 class ConnectionRepository
 {
     protected ApiGatewayManagementApiClient $apiGatewayManagementApiClient;
+    protected SubscriptionRepository $subscriptionRepository;
 
     public function __construct(
-        protected SubscriptionRepository $subscriptionRepository,
+        SubscriptionRepository $subscriptionRepository,
         array $config
     ) {
+        $this->subscriptionRepository = $subscriptionRepository;
+
         $this->apiGatewayManagementApiClient = new ApiGatewayManagementApiClient(array_merge($config['connection'], [
             'version' => '2018-11-29',
             'endpoint' => "https://{$config['api']['id']}.execute-api.{$config['connection']['region']}.amazonaws.com/{$config['api']['stage']}/",

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -13,9 +13,12 @@ use Throwable;
 
 class Handler extends WebsocketHandler
 {
+    protected SubscriptionRepository $subscriptionRepository;
+    protected ConnectionRepository $connectionRepository;
+
     public function __construct(
-        protected SubscriptionRepository $subscriptionRepository,
-        protected ConnectionRepository $connectionRepository
+        SubscriptionRepository $subscriptionRepository,
+        ConnectionRepository $connectionRepository
     ) {
         $this->subscriptionRepository = $subscriptionRepository;
         $this->connectionRepository = $connectionRepository;


### PR DESCRIPTION
Hi there - thank you for this great project, which made it a piece of cake to add websocket support to my (Bref based) AWS Lambda "serverless Laravel" project!

I just followed the (very clear and complete) docs, did a tiny bit tweaking and debugging (mainly in my frontend code), and abracadabra "it all just worked".

However I would like to propose a little change - I'm using PHP 7.4, and although I know the project states PHP 8 as the required minimum version, I saw that with a couple of very simple syntactic changes we can make it work with PHP 7.4 (I didn't want to move to PHP 8 for a number of reasons).

Point is that PHP 7.4 does not support `protected` in parameter declarations, so if we just move that to a property declaration then PHP 7.4 is happy, and all is well.

Tested it and all looking good, this should be a very low risk change (while I was at it I also removed an unused import).

Let me know if it looks okay, thanks in advance!

P.S. just now I saw in an Issue (https://github.com/georgeboot/laravel-echo-api-gateway/issues/10) that you'd like to 'gently encourage' people to upgrade their PHP - however, with all due respect, this stuff works equally well with PHP 7.4, and people can have pragmatic reasons to stick with 7.4 - I'd say there's no real reason here to force PHP 8 (but I have no problem with declaring PHP 8 as a requirement in composer.json, I can choose to obey or ignore that)

P.S. there's one other small change that I'd like to propose (but I will do that in a separate pull request): the frontend (Javascript) code contains some `console.log` statements - these are super useful, but my proposal would be that we might make this configurable (meaning we can switch it on or off) e.g. via a the `options` object that's passed to `new Echo` ... just a heads-up, I'll put the details in another PR