### PR TITLE
Add authorization headers

### DIFF
--- a/js-src/Websocket.ts
+++ b/js-src/Websocket.ts
@@ -136,9 +136,15 @@ export class Websocket {
         if (channel.name.startsWith('private-') || channel.name.startsWith('presence-')) {
             console.log(`Sending auth request for channel ${channel.name}`)
 
+            if (this.options.bearerToken) {
+              this.options.auth.headers['Authorization'] = 'Bearer ' + this.options.bearerToken;
+            }
+
             axios.post(this.options.authEndpoint, {
                 socket_id: this.getSocketId(),
                 channel_name: channel.name,
+            }, {
+              headers: this.options.auth.headers || {}
             }).then((response: AxiosResponse) => {
                 console.log(`Subscribing to channels ${channel.name}`)
 


### PR DESCRIPTION
Before, if you included the following authorization headers to the Echo connection block, it would be ignored and private channels would fail to connect:

`
    auth: {
      headers: {
        Authorization: "Bearer {TOKEN}",
      },
    }
`

This PR makes it so if you included `auth.headers.Authorization` or the shorter `bearerToken` options, it will now add it to the authentication headers.